### PR TITLE
Implement automatic re-authorization when Google token expires

### DIFF
--- a/src/bunq_google_sheets_sync/bunq.clj
+++ b/src/bunq_google_sheets_sync/bunq.clj
@@ -73,7 +73,7 @@
   ^Credential
   [secrets]
   (-> (create-authorization-flow secrets)
-      (oauth2/authorize-local! 18888)))
+      (oauth2/authorize! 18888)))
 
 ;; ## API Context
 

--- a/src/bunq_google_sheets_sync/google.clj
+++ b/src/bunq_google_sheets_sync/google.clj
@@ -41,12 +41,12 @@
         (.setCredentialDataStore store)
         (.build))))
 
-(defn authorize!
+(defn authorize-and-run!
   "Given a map of `:client-id`, `:client-secret` and `:redirect-uris`, this
    will initiate a local authorization flow, opening a browser window for
    confirmation, and persisting the credentials locally for reuse."
   ^Credential
-  [secrets]
+  [secrets f]
   (-> (as-google-client-secrets secrets)
       (create-authorization-flow)
-      (oauth2/authorize-local!)))
+      (oauth2/authorize-and-run! f)))


### PR DESCRIPTION
Since, most likely, we're using a test token, we'll run into an expiry
of the refresh token (after around a week). For a production token, this
won't be an issue (but it requires review of the app by Google).